### PR TITLE
Backend: 상영일정, 좌석 조회 API에 예매상태 추가

### DIFF
--- a/docs/api_definition.md
+++ b/docs/api_definition.md
@@ -198,19 +198,22 @@
             "showId": 1001,
             "theaterName": "1관",
             "showStartTime": "2021-05-14 14:10",
-            "seatsInfo": "168/240"
+            "seatsCapacity": 96,
+            "seatsAvailable": 93
           },
           {
             "showId": 1002,
             "theaterName": "2관",
             "showStartTime": "2021-05-14 15:10",
-            "seatsInfo": "209/212"
+            "seatsCapacity": 88,
+            "seatsAvailable": 88
           },
           {
             "showId": 1003,
             "theaterName": "1관",
             "showStartTime": "2021-05-14 16:40",
-            "seatsInfo": "189/240"
+            "seatsCapacity": 96,
+            "seatsAvailable": 96
           }
         ]
       },
@@ -221,19 +224,22 @@
             "showId": 1004,
             "theaterName": "1관",
             "showStartTime": "2021-05-15 10:20",
-            "seatsInfo": "230/240"
+            "seatsCapacity": 96,
+            "seatsAvailable": 63
           },
           {
             "showId": 1005,
             "theaterName": "2관",
             "showStartTime": "2021-05-15 11:10",
-            "seatsInfo": "208/212"
+            "seatsCapacity": 88,
+            "seatsAvailable": 83
           },
           {
             "showId": 1006,
             "theaterName": "1관",
             "showStartTime": "2021-05-15 13:40",
-            "seatsInfo": "239/240"
+            "seatsCapacity": 96,
+            "seatsAvailable": 94
           }
         ]
       }

--- a/server/api/serializers.py
+++ b/server/api/serializers.py
@@ -96,7 +96,8 @@ class ShowListSerializer(serializers.Serializer):
     showId = serializers.IntegerField()
     theaterName = serializers.CharField()
     showStartTime = serializers.DateTimeField()
-    seatsInfo = serializers.CharField()
+    seatsCapacity = serializers.IntegerField()
+    seatsAvailable = serializers.IntegerField()
 
 
 class ShowScheduleSerializer(serializers.Serializer):


### PR DESCRIPTION
Detail
======
 - 좌석 조회 API
   - seats 2차원배열로 표시
   - seatType 예매된 자리 표시
   - bookingCount 추가
 - 상영일정 조회 API
   - 예매율 nn/nn에서 seatsCapacity: nn, seatsAvailable: nn 으로 변경
   - seatsAvailable 구현

Test
======
 - /shows?movie_id=1
   - 2021-05-15 5번 show
   - 83/88
 - /shows/5/seats
   - 100~103번자리 예매